### PR TITLE
Fix/fa fetching users data for inside announcement and replies

### DIFF
--- a/pages/announcements/[announceId]/index.js
+++ b/pages/announcements/[announceId]/index.js
@@ -14,6 +14,7 @@ export default function AnnouncementId() {
     const announceId = router.query.announceId
     const [announceInfo, setAnnounceInfo] = useState({})
     const [commentsInfo, setCommentsInfo] = useState([])
+    const [posterInfo, setPosterInfo] = useState((""))
     const notifySuccess = useToastify("success", "Comentario publicado")
 
     //petición a la api para setear anuncios
@@ -32,8 +33,18 @@ export default function AnnouncementId() {
                 // console.log("la data", data)
                 if (data.data) {
                     const announcement = data.data.announcementById
-                    
                     setAnnounceInfo(announcement)
+                    if(announcement.user){
+                        setPosterInfo(announcement.user.name)
+                    } else {
+                        if(announcement.teacher){
+                            setPosterInfo(announcement.teacher.name)
+                        } else {
+                            if(announcement.parent){
+                                setPosterInfo(announcement.parent.name)
+                            }
+                        }
+                    }
                     
                     setCommentsInfo(announcement.replies.reverse())
                 }

--- a/pages/announcements/[announceId]/index.js
+++ b/pages/announcements/[announceId]/index.js
@@ -7,6 +7,7 @@ import CommentBox from '../../../components/CommentBox';
 import AllComments from '../../../components/AllComments';
 import { ToastContainer } from 'react-toastify';
 import useToastify from '../../../components/useToastify';
+import { format } from 'date-fns';
 
 
 export default function AnnouncementId() {
@@ -33,15 +34,16 @@ export default function AnnouncementId() {
                 // console.log("la data", data)
                 if (data.data) {
                     const announcement = data.data.announcementById
+                    // console.log("soy info dentro del anuncio", announcement)
                     setAnnounceInfo(announcement)
                     if(announcement.user){
                         setPosterInfo(announcement.user.name)
                     } else {
                         if(announcement.teacher){
-                            setPosterInfo(announcement.teacher.name)
+                            setPosterInfo(`${announcement.teacher.name} ${announcement.teacher.lastNameA} ${announcement.teacher.lastNameB}`)
                         } else {
                             if(announcement.parent){
-                                setPosterInfo(announcement.parent.name)
+                                setPosterInfo(`${announcement.parent.name} ${announcement.parent.lastNameA} ${announcement.parent.lastNameB}`)
                             }
                         }
                     }
@@ -69,12 +71,12 @@ export default function AnnouncementId() {
                         btnTxtModal={<h4>Anuncio</h4>}
                         route={"/announcements"} />
 
-                    {!!announceInfo.user &&
+                    {(!!posterInfo) &&
                         <PostAnnouncement
                             coverimg={"/img/kid&parent.jpeg"}
-                            userName={announceInfo.user.name}
-                            role={announceInfo.user.role}
-                            date={"--fecha--"}
+                            userName={posterInfo}
+                            role={(!!announceInfo.user) ? "Administrador" : "Profesor"}
+                            date={format(new Date(announceInfo.createdAt), 'dd/MM/yyyy')}
                             announcementTitle={announceInfo.announcementTitle}
                             textInfo={announceInfo.announcementText}
                             component={<CommentBox/>}

--- a/pages/announcements/index.js
+++ b/pages/announcements/index.js
@@ -49,7 +49,7 @@ export default function Announcements() {
     useEffect(() => {
         const token = localStorage.getItem("token");
         const userData = JSON.parse(atob(token.split(".")[1]));
-        console.log("user data", userData)
+        console.log("user data del token", userData)
         const userRole = () => {
             if (userData.role === "admin") {
                 return "user";
@@ -75,23 +75,24 @@ export default function Announcements() {
             })
                 .then(response => response.json())
                 .then(data => {
+                    console.log("soy data del fetch al usuario", data)
+                    let schoolId = ''
                     if (data.data) {
                         const userFetchedInfo = data.data
                         console.log('fetchedInfo', userFetchedInfo)
-                        let schoolId = ''
                         if (userFetchedInfo.userById) {
                             schoolId = userFetchedInfo.userById.school._id;
-                        }else {
-                            if(userFetchedInfo.teacherById){
+                        } else {
+                            if (userFetchedInfo.teacherById) {
                                 schoolId = userFetchedInfo.teacherById.school
-                            } else {
-                                if (userFetchedInfo.parentById){
-                                    schoolId = userFetchedInfo.parentById.school
-                                }
                             }
                         }
-                          setUserSchoolId(schoolId);
+                    } else {
+                        if (userData.role === "parent") {
+                            schoolId = userData.schoolId
+                        }
                     }
+                    setUserSchoolId(schoolId);
                 });
         }
     }, []);

--- a/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
+++ b/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
@@ -44,6 +44,7 @@ export default function AnnouncementId() {
                         }
                     }
                     const replies = announcement.replies
+                    console.log("respuestas", replies)
                     setRepliesInfo(replies.reverse())
                 }
             })
@@ -79,6 +80,9 @@ export default function AnnouncementId() {
                                 repliesInfo.map(reply => (
                                     <AllComments
                                         key={reply.id}
+                                        userName={"-nombre-"}
+                                        role={reply.teacher ? "Profesor" : reply.parent ? "Tutor" : "Administrador"}
+                                        date={format(new Date(announceInfo.createdAt), 'dd/MM/yyyy')}
                                         textInfo={reply.message}
                                     />
                                 ))}

--- a/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
+++ b/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
@@ -7,6 +7,7 @@ import AllComments from '../../../../components/AllComments';
 import CommentBox from '../../../../components/CommentBox';
 import { ToastContainer } from 'react-toastify';
 import useToastify from '../../../../components/useToastify';
+import { format } from 'date-fns';
 
 
 export default function AnnouncementId() {
@@ -15,6 +16,7 @@ export default function AnnouncementId() {
     const announceId = router.query.groupAnnouncementId
     const [announceInfo, setAnnounceInfo] = useState({})
     const [repliesInfo, setRepliesInfo] = useState([])
+    const [posterInfo, setPosterInfo] = useState((""))
     const notifySuccess = useToastify("success", "Comentario publicado")
 
     //petición a la api para setear anuncios
@@ -34,6 +36,13 @@ export default function AnnouncementId() {
                 if (data.data) {
                     const announcement = data.data.announcementById
                     setAnnounceInfo(announcement)
+                    if (announcement.user) {
+                        setPosterInfo(announcement.user.name)
+                    } else {
+                        if (announcement.teacher) {
+                            setPosterInfo(`${announcement.teacher.name} ${announcement.teacher.lastNameA} ${announcement.teacher.lastNameB}`)
+                        }
+                    }
                     const replies = announcement.replies
                     setRepliesInfo(replies.reverse())
                 }
@@ -41,10 +50,10 @@ export default function AnnouncementId() {
 
     }, [router.query]);
 
-    useEffect(()=> {
+    useEffect(() => {
         const notifCommentCreation = localStorage.getItem("notifCommentCreation")
         if (notifCommentCreation === "true") {
-            notifySuccess() 
+            notifySuccess()
             localStorage.setItem('notifCommentCreation', 'false')
         }
     })
@@ -57,23 +66,25 @@ export default function AnnouncementId() {
                         btnTxtModal={<h4>Anuncio</h4>}
                         route={`/grouplist/${groupId}/groupannouncements/`} />
 
-                    {!!announceInfo.user &&
+                    {(!!posterInfo) &&
                         <PostAnnouncement
                             coverimg={"/img/kid&parent.jpeg"}
-                            userName={announceInfo.user.name}
-                            role={announceInfo.user.role}
-                            date={"--fecha--"}
+                            userName={posterInfo}
+                            role={(!!announceInfo.user) ? "Administrador" : "Profesor"}
+                            date={format(new Date(announceInfo.createdAt), 'dd/MM/yyyy')}
                             announcementTitle={announceInfo.announcementTitle}
                             textInfo={announceInfo.announcementText}
                             component={<CommentBox />}
                             component2={repliesInfo.length > 0 &&
                                 repliesInfo.map(reply => (
-                                    <AllComments 
-                                    key={reply.id} 
-                                    textInfo={reply.message}
+                                    <AllComments
+                                        key={reply.id}
+                                        textInfo={reply.message}
                                     />
                                 ))}
-                        />}
+                        />
+
+                    }
                 </div>
             </div>
             <ToastContainer />

--- a/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
+++ b/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
@@ -44,7 +44,7 @@ export default function AnnouncementId() {
                         }
                     }
                     const replies = announcement.replies
-                    console.log("respuestas", replies)
+                    
                     setRepliesInfo(replies.reverse())
                 }
             })

--- a/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
+++ b/pages/grouplist/[groupId]/groupannouncements/[groupAnnouncementId].js
@@ -78,11 +78,12 @@ export default function AnnouncementId() {
                             component={<CommentBox />}
                             component2={repliesInfo.length > 0 &&
                                 repliesInfo.map(reply => (
+
                                     <AllComments
                                         key={reply.id}
-                                        userName={"-nombre-"}
+                                        userName={"id del usuario para hacer fetch y obtener su nombre"}
                                         role={reply.teacher ? "Profesor" : reply.parent ? "Tutor" : "Administrador"}
-                                        date={format(new Date(announceInfo.createdAt), 'dd/MM/yyyy')}
+                                        date={format(new Date(reply.createdAt), 'dd/MM/yyyy')}
                                         textInfo={reply.message}
                                     />
                                 ))}

--- a/pages/grouplist/[groupId]/groupannouncements/index.js
+++ b/pages/grouplist/[groupId]/groupannouncements/index.js
@@ -45,6 +45,7 @@ export default function GroupAnnouncements() {
         .then(data => {
           if (data.data) {
             const allAnnouncements = data.data.announcementsFound
+            console.log("info de all anuncios ruta /groupannouncements", allAnnouncements)
             setAnnounceInfo(allAnnouncements.reverse())
           }
         })
@@ -68,7 +69,7 @@ export default function GroupAnnouncements() {
               <CardAnnouncement
                 // coverimg={"/img/kid&parent.jpeg"}
                 userName={announce.user}
-                role={'-rol aquí-'}
+                role={(!!announce.user) ? "Administrador" : "Profesor"}
                 date={format(new Date(announce.createdAt), 'dd/MM/yyyy')}
                 announcementTitle={announce.announcementTitle} />
             </Link>


### PR DESCRIPTION
-Se arregla error que no permitía ver o agregar anuncios en el primer login del usuario 
-Se arregla error de anuncios desplegandose solo cuando el usuario que lo publicaba lo clickeaba. ahora todos los usuarios pueden ver y entrar a todos los anuncios
-Se agrega nombre, rol y fecha dentro de posts de anuncio 
-En ruta de /groupannouncements:
   -se agrega rol y fecha a cards de anuncios
   -se agrega rol y fecha dentro de replies

