### PR TITLE
Fix/fa school announcements route for teacher and parent

### DIFF
--- a/components/FormLogin/FormLogin.js
+++ b/components/FormLogin/FormLogin.js
@@ -72,10 +72,10 @@ export default function FormLogin() {
       }
       else {
         if (userRole === "teacher") {
-          router.push("/teacher/yourgroups")
+          router.push("/announcements")
         } else {
           if (userRole === "parent") {
-            router.push("/parent/yourgroups")
+            router.push("/announcements")
           } else {
             if (user && user.school) {
               router.push("/announcements")

--- a/components/Navbar/index.js
+++ b/components/Navbar/index.js
@@ -12,7 +12,7 @@ import { SlClose } from "react-icons/sl"
 import { FaBars } from "react-icons/fa"
 import { SidebarData } from "../SideBar/SidebarData"
 import { GoSignOut } from "react-icons/go"
-
+import { AiFillHome } from "react-icons/ai";
 
 export default function Navbar() {
     const [sidebar, setSidebar] = useState(false)
@@ -50,13 +50,13 @@ export default function Navbar() {
         <div className="navigation d-flex col-12 col-lg-12 ">
 
             <div className="d-flex col-2 col-lg-2 justify-content-center  align-items-center">
-                {(userRole == "admin") ?
+                {(userRole) ?
                     <Link onClick={showSidebar} href="#">
                         <div className="navigation__navmenuBG d-flex justify-content-center  align-items-center">
 
                             <FaBars />
                         </div>
-                    </Link> : <p></p>
+                    </Link> : null
                 }
             </div>
 
@@ -69,6 +69,12 @@ export default function Navbar() {
                         </a>
                     </li>
 
+                    <li className="nav-text">
+                        <Link href={userRole ==="teacher" ? "/grouplist" : userRole ==="teacher" ? "/teacher/yourgroups" : "/parent/yourgroups"}>
+                            <AiFillHome />
+                            <div className="nav-span">Grupos</div>
+                        </Link>
+                    </li>
                     {SidebarData.map((item, index) => {
                         return (
                             <li key={index} className={item.className}>

--- a/components/SideBar/SidebarData.js
+++ b/components/SideBar/SidebarData.js
@@ -8,14 +8,14 @@ import { RiParentFill } from "react-icons/ri";
 
 
 export const SidebarData = [
+  // {
+  //   title: 'Grupos',
+  //   path: '/grouplist',
+  //   icon: <AiFillHome/>,
+  //   className: 'nav-text',
+  // },
   {
-    title: 'Grupos',
-    path: '/grouplist',
-    icon: <AiFillHome/>,
-    className: 'nav-text',
-  },
-  {
-    title: 'Anuncios',
+    title: 'Anuncios Esc.',
     path: '/announcements',
     icon: <MdOutlineMessage/>,
     className: 'nav-text',

--- a/pages/announcements/index.js
+++ b/pages/announcements/index.js
@@ -126,9 +126,10 @@ export default function Announcements() {
                     <div className='d-flex col-11 col-lg-8 justify-content-between align-items-center'>
                         <div className='d-flex col-8 col-lg-10 align-items-center'>
                             <h4>Anuncios escolares </h4>
+                            {(userDataRole !== "parent") &&
                             <Link href={"/announcements/newannouncement"}>
                                 <button className='btn-form bg-success'>Anuncio <BsPlusCircle /></button>
-                            </Link>
+                            </Link>}
                         </div>
                         <div className='col-4'>
                             <Link href={`${routeBtnGroups()}`} className="d-flex align-items-center" style={{textDecoration:"none"}}>

--- a/pages/announcements/index.js
+++ b/pages/announcements/index.js
@@ -131,7 +131,7 @@ export default function Announcements() {
                             </Link>
                         </div>
                         <div className='col-4'>
-                            <Link href={`${routeBtnGroups()}`} className="d-flex align-items-center" >
+                            <Link href={`${routeBtnGroups()}`} className="d-flex align-items-center" style={{textDecoration:"none"}}>
                                 <button className='btn-form'>Grupos <BsArrowRightCircle /></button>
                             </Link>
                         </div>

--- a/pages/announcements/index.js
+++ b/pages/announcements/index.js
@@ -15,6 +15,7 @@ import { format } from 'date-fns';
 export default function Announcements() {
     const [announceInfo, setAnnounceInfo] = useState([])
     const [userSchoolId, setUserSchoolId] = useState("")
+    const [userDataRole, setUserDataRole] = useState("")
     const notifySuccess = useToastify("success", "¡Anuncio creado con éxito!")
     console.log('userSchoolId', userSchoolId)
 
@@ -49,6 +50,7 @@ export default function Announcements() {
     useEffect(() => {
         const token = localStorage.getItem("token");
         const userData = JSON.parse(atob(token.split(".")[1]));
+        setUserDataRole(userData.role)
         console.log("user data del token", userData)
         const userRole = () => {
             if (userData.role === "admin") {
@@ -102,6 +104,21 @@ export default function Announcements() {
             fetchAnnouncements();
         }
     }, [fetchAnnouncements, userSchoolId]);
+
+    const routeBtnGroups = () => {
+        if(userDataRole === "admin"){
+            return "/grouplist"
+        } else {
+            if(userDataRole === "teacher"){
+                return "/teacher/yourgroups"
+            } else {
+                if(userDataRole === "parent") {
+                    return "/parent/yourgroups"
+                }
+            }
+        }
+    }
+    
     return (
         <Layout>
             <div>
@@ -114,7 +131,7 @@ export default function Announcements() {
                             </Link>
                         </div>
                         <div className='col-4'>
-                            <Link href={"/grouplist"} className="d-flex align-items-center">
+                            <Link href={`${routeBtnGroups()}`} className="d-flex align-items-center" >
                                 <button className='btn-form'>Grupos <BsArrowRightCircle /></button>
                             </Link>
                         </div>

--- a/pages/grouplist/[groupId]/groupannouncements/index.js
+++ b/pages/grouplist/[groupId]/groupannouncements/index.js
@@ -17,6 +17,7 @@ export default function GroupAnnouncements() {
   const router = useRouter()
   const groupId = router.query.groupId
   const [announceInfo, setAnnounceInfo] = useState([])
+  const [userRole, setUserRole] = useState("")
   const notifySuccess = useToastify("success", "¡Anuncio creado con éxito!")
 
   //check de item que viene desde newAnnouncement para notificación de anuncio creado
@@ -32,6 +33,8 @@ export default function GroupAnnouncements() {
   //petición a la api para setear anuncios
   useEffect(() => {
     const token = localStorage.getItem("token");
+    const userData = JSON.parse(atob(token.split(".")[1]));
+    setUserRole(userData.role)
     if (token) {
       //groupId anuncios
       fetch(`https://api.toknow.online/announcement/group/${groupId}`, {
@@ -56,9 +59,12 @@ export default function GroupAnnouncements() {
       <div>
         <ArrowGoBack
           btnTxtModal={<h4>Anuncios grupales</h4>}
-          btnTxtModal2nd={<Link href={`/grouplist/${groupId}/newgroupannouncement`}>
-            <button className='btn-form bg-success'>Anuncio <BsPlusCircle /></button>
-          </Link>}
+          btnTxtModal2nd={
+            userRole !== "parent" ? (
+              <Link href={`/grouplist/${groupId}/newgroupannouncement`}>
+                <button className='btn-form bg-success'>Anuncio <BsPlusCircle /></button>
+              </Link>) : null
+          }
           route={`/grouplist/${groupId}`}
         />
         {(announceInfo.length > 0) ?

--- a/pages/grouplist/[groupId]/index.js
+++ b/pages/grouplist/[groupId]/index.js
@@ -115,9 +115,11 @@ export default function GroupDetail() {
                 <div>
                     <ArrowGoBack
                         btnTxtModal={
-                            <Link href={'/grouplist/[groupId]/newgroupannouncement'} as={`/grouplist/${groupId}/newgroupannouncement`} >
-                                <button className='btn-form bg-success'>Crear Anuncio</button>
-                            </Link>}
+                            userRole !== "parent" ? (
+                                <Link href={'/grouplist/[groupId]/newgroupannouncement'} as={`/grouplist/${groupId}/newgroupannouncement`} >
+                                    <button className='btn-form bg-success'>Crear Anuncio</button>
+                                </Link>) : null
+                        }
                         btnTxtModal2nd={
                             <Link href={'/grouplist/[groupId]/groupannouncements'} as={`/grouplist/${groupId}/groupannouncements`} >
                                 <button className='btn-form'>Anuncios grupales</button>

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,7 +40,7 @@ useEffect(() => {
         </section>
 
         <section className='col-12 col-lg-4'>
-          <h5 className='landingLogin mt-3'>Acceder</h5>
+          <h5 className='landingLogin mt-3'>Iniciar sesión</h5>
           <FormLogin />
           <div className='d-flex justify-content-lg-between'>
             {/* <div className='col-lg-5'>sus datos están seguros con nosotros</div> */}


### PR DESCRIPTION
-se implementa página anuncios escolares en flujo de teacher y parent
-boton de grupos en página de anuncios redirecciona a ruta grupos dependiendo del rol
-rol parent ya no puede ver botones de 'crear anuncio' en /announcement, /groupid y /groupannouncements
-rol parent y teacher ya tienen menú hamburguesa con ruta de anuncios escolares y ruta modificada que los lleva a sus grupos